### PR TITLE
Removing extra 'pre'  from gem versions

### DIFF
--- a/uat-core/lib/uat/core/version.rb
+++ b/uat-core/lib/uat/core/version.rb
@@ -1,5 +1,5 @@
 module UAT
   module Core
-    VERSION = "0.0.1.pre"
+    VERSION = "0.0.1"
   end
 end

--- a/uat-discovery/lib/uat/discovery/version.rb
+++ b/uat-discovery/lib/uat/discovery/version.rb
@@ -1,5 +1,5 @@
 module UAT
   module Discovery
-    VERSION = "0.0.2.pre"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
Removing extra 'pre' from gem versions